### PR TITLE
fix typo in setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='qose',
     version='0.1',
-    packages=['qose'],
+    packages=['src'],
     url='',
     license='',
     author='Aroosa Ijaz, Kathleen Hamilton, Jelena Mackeprang,Roeland Wiersema',
@@ -11,5 +11,5 @@ setup(
     description='',
     install_requires=['numpy', 'pennylane', 'torch', 'autograd'],
     python_requires='>=3.6',
-    package_dir = {'qose': 'qose'},
+    package_dir = {'src': 'src'},
 )


### PR DESCRIPTION
`pip install .` should work now